### PR TITLE
make scripts target simpler

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install tap-spec --save-dev
 {
   "name": "module-name",
   "scripts": {
-    "test": "node ./test/tap-test.js | node_modules/.bin/tspec"
+    "test": "node ./test/tap-test.js | tspec"
   }
 }
 ```


### PR DESCRIPTION
npm adds node_modules/.bin to PATH when running commands from the scripts targets.

This means you can use just `tspec`
