### PR TITLE
Fail if not ok.

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -53,6 +53,9 @@ tap.on('results', function (_res) {
       out.push('    ' + chalk.red('✗') + ' ' + chalk.red(error) + '\n');
     });
   }
+  else if (!res.ok) {
+    out.push('  ' + chalk.red('Fail!') + '\n');
+  }
   else{
     out.push('  ' + chalk.green('Pass!') + '\n');
   }


### PR DESCRIPTION
Currently if you have a node program that throws an error before outputting tap, `tap-spec` outputs `Pass!` and exits with `1`.

This is confusing, it should probably exit with 1 and output `Fail!`
