### PR TITLE
add character support for win32 console

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -12,27 +12,40 @@ var currentTestName = '';
 var errors = [];
 var res;
 
+var symbols = {
+    ok: '\u2713',
+    err: '\u2717'
+};
+
+// win32 console default output fonts don't support tick/cross
+if (process && process.platform === 'win32') {
+  symbols = {
+    ok: '\u221A',
+    err: '\u00D7'
+  };
+}
+
 out.push('\n');
 
 tap.on('comment', function (comment) {
   currentTestName = comment;
-  
+
   if (/^tests\s+[1-9]/gi.test(comment)) comment = chalk.white(comment);
   else if (/^pass\s+[1-9]/gi.test(comment)) comment = chalk.green(comment);
   else if (/^fail\s+[1-9]/gi.test(comment)) comment = chalk.red(comment);
   else if (/^ok$/gi.test(comment)) return;
   else out.push('\n');
-  
+
   out.push('  ' + comment + '\n');
 });
 
 tap.on('assert', function (res) {
   var output = (res.ok)
-    ? chalk.green('\u2713')
-    : chalk.red('✗');
-  
+    ? chalk.green(symbols.ok)
+    : chalk.red(symbols.err);
+
   if (!res.ok) errors.push(currentTestName + ' ' + res.name);
-  
+
   out.push('    ' + output + ' ' + chalk.gray(res.name) + '\n');
 });
 
@@ -45,12 +58,12 @@ tap.on('results', function (_res) {
   if (errors.length) {
     var past = (errors.length == 1) ? 'was' : 'were';
     var plural = (errors.length == 1) ? 'failure' : 'failures';
-    
+
     out.push('  ' + chalk.red('Failed Tests: '));
     out.push('There ' + past + ' ' + chalk.red(errors.length) + ' ' + plural + '\n\n');
-    
+
     errors.forEach(function (error) {
-      out.push('    ' + chalk.red('✗') + ' ' + chalk.red(error) + '\n');
+      out.push('    ' + chalk.red(symbols.err) + ' ' + chalk.red(error) + '\n');
     });
   }
   else if (!res.ok) {
@@ -64,7 +77,7 @@ tap.on('results', function (_res) {
 process.stdin
   .pipe(dup)
   .pipe(process.stdout);
-  
+
 process.on('exit', function () {
   if (errors.length || !res.ok) {
     process.exit(1);


### PR DESCRIPTION
This adds support for characters that display correctly in the default win32 console, as the current ones are unsupported and leave square markers in their place.
