### PR TITLE
Remove count from print out

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = function() {
     
     else {
       // Test name
-      comment = testNumber + ') ' + comment + '\n';
+      comment = comment + '\n';
       out.push('\n');
     }
 


### PR DESCRIPTION
This is a super minor edit, it does not effect any of the internal logic for counting tests.  This way the numbers can easily be rolled back in when the underlying tap parser is updated.
