### PR TITLE
zero length fix

### DIFF
--- a/lib/utils/l-trim-list.js
+++ b/lib/utils/l-trim-list.js
@@ -1,22 +1,22 @@
 var _ = require('lodash');
 
 module.exports = function (lines) {
-  
+
   var leftPadding;
-  
+
   // Get minimum padding count
   _.each(lines, function (line) {
-    
-    var spaceLen = line.match(/^\s+/)[0].length;
-    
+    var match = line.match(/^\s+/);
+    var spaceLen = match ? match[0].length : 0;
+
     if (leftPadding === undefined || spaceLen < leftPadding) {
       leftPadding = spaceLen;
     }
   });
-  
+
   // Strip padding at beginning of line
   return _.map(lines, function (line) {
-    
+
     return line.slice(leftPadding);
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tap-spec",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Formatted TAP output like Mocha's spec reporter",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
l-trim-list.js failed at failure reporting when the failed line was surrounded by zero length lines.

E.g.

10
11 t.equal(1, 2);
12   ^

10 and 12 are zero length lines and the report fails.