### PR TITLE
Reduce spacing

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = function (spec) {
 
   parser.on('test', function (test) {
 
-    output.push('\n' + pad(format.underline(test.name)) + '\n\n');
+    output.push('\n' + pad(format.underline(test.name)) + '\n');
   });
 
   // Passing assertions


### PR DESCRIPTION
well, this is a matter of personal preference, but...

![pasted_image_1_14_16__12_43_pm](https://cloud.githubusercontent.com/assets/74385/12315992/6d600196-babc-11e5-8d58-4ec641ece4f0.png)

it would be nice to be able to show more lines in the output. there are a lot of cases when each test only has 1 assert, and it takes up too much space. this PR removes the extra newline after tests.
