### PR TITLE
Add the noSucces option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,24 @@ tape test/index.js | node_modules/.bin/tap-spec
 npm install testling -g
 testling test/index.js | node_modules/.bin/tap-spec
 ```
+
+## Options
+
+### Discard success message:
+
+This option is especially useful when fix failing tests in large tests suite.
+
+```bash
+tape test/index.js | node_modules/.bin/tap-spec --nosuccess
+```
+
+```js
+var test = require('tape');
+var tapSpec = require('tap-spec');
+
+test.createStream()
+  .pipe(tapSpec({
+    noSuccess: true
+  }))
+  .pipe(process.stdout);
+```

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,18 +1,33 @@
 #!/usr/bin/env node
+var argv = require('yargs').argv;
+
+if (argv.h || argv.help) {
+  var usage = [
+    'Usage: tap-spec [--nosuccess] [-h, --help]',
+    '',
+    'Options:',
+    '  --nosuccess\t\t\t\tDiscard success messages',
+    '  -h, --help \t\t\t\tDisplay this help message'
+  ].join('\n');
+  console.log(usage);
+  process.exit(0);
+}
 
 var tapSpec = require('../');
-var tapSpec = tapSpec();
+var stream = tapSpec({
+  noSuccess: argv.nosuccess
+});
 
 process.stdin
-  .pipe(tapSpec)
+  .pipe(stream)
   .pipe(process.stdout);
 
 process.on('exit', function (status) {
-  
+
   if (status === 1) {
     process.exit(1);
   }
-  
+
   if (tapSpec.failed) {
     process.exit(1);
   }

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = function (spec) {
   spec = spec || {};
 
   var OUTPUT_PADDING = spec.padding || '  ';
+  var noSuccess = spec.noSuccess;
 
   var output = through();
   var parser = tapOut();
@@ -31,6 +32,8 @@ module.exports = function (spec) {
 
   // Passing assertions
   parser.on('pass', function (assertion) {
+
+    if (noSuccess) return;
 
     var glyph = format.green(symbols.tick);
     var name = format.dim(assertion.name);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "pretty-ms": "^2.1.0",
     "repeat-string": "^1.5.2",
     "tap-out": "^1.4.1",
-    "through2": "^2.0.0"
+    "through2": "^2.0.0",
+    "yargs": "^3.32.0"
   },
   "bin": {
     "tspec": "bin/cmd.js",


### PR DESCRIPTION
To both CLI (`--nosuccess`) and API (`tapRedux({noSuccess: true}`)
to allow users to discard success lines.

It's super useful to be able to discard useless success lines on large
test suites. The only caveat is that comments (ie, error messages?) might be given out of context.

Also adds the `-h, --help` option to show command usage.
