### PR TITLE
Added support for in Script parsing by switching to tap-parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 
-var tapOut = require('tap-out');
+var tapOut = require('tap-parser');
 var through = require('through2');
 var duplexer = require('duplexer');
 var format = require('chalk');
@@ -22,58 +22,70 @@ module.exports = function (spec) {
   var stream = duplexer(parser, output);
   var startTime = new Date().getTime();
 
+  var errorSummary = {};
+  var currTest = '';
+
   output.push('\n');
 
-  parser.on('test', function (test) {
-
-    output.push('\n' + pad(format.underline(test.name)) + '\n\n');
-  });
-
-  // Passing assertions
-  parser.on('pass', function (assertion) {
-
-    var glyph = format.green(symbols.tick);
-    var name = format.dim(assertion.name);
-
-    output.push(pad('  ' + glyph + ' ' + name + '\n'));
-  });
-
-  // Failing assertions
-  parser.on('fail', function (assertion) {
-
-    var glyph = symbols.cross;
-    var title =  glyph + ' ' + assertion.name;
-    var raw = format.cyan(prettifyRawError(assertion.error.raw));
-    var divider = _.fill(
-      new Array((title).length + 1),
-      '-'
-    ).join('');
-
-    output.push('\n' + pad('  ' + format.red(title) + '\n'));
-    output.push(pad('  ' + format.red(divider) + '\n'));
-    output.push(raw);
-
-    stream.failed = true;
-  });
-
   parser.on('comment', function (comment) {
+    comment = comment.replace(/^#\s+|[\n\s]+$/g, '');
+    if(/^(tests|pass|fail)/.test(comment)) { return; }
+    output.push('\n' + pad(format.underline(comment)) + '\n\n');
+
+    currTest = comment;
+    errorSummary[currTest] = [];
+  });
+
+  parser.on('assert', function (assertion) {
+
+    if(assertion.skip || assertion.todo) { return; }
+
+    var name = assertion.name;
+
+    if(assertion.ok) {
+      // Passing assertions
+      var glyph = format.green(symbols.tick);
+
+      output.push(pad('  ' + glyph + ' ' + format.dim(name) + '\n'));
+    } else {
+      // Failing assertions
+      var glyph = symbols.cross;
+      var title =  glyph + ' ' + name;
+      var raw = format.cyan(prettifyError(assertion.diag));
+      var divider = _.fill(
+        new Array((title).length + 1),
+        '-'
+      ).join('');
+
+      errorSummary[currTest].push(name);
+
+      output.push('\n' + pad('  ' + format.red(title) + '\n'));
+      output.push(pad('  ' + format.red(divider) + '\n'));
+      output.push(raw);
+
+      markFailed();
+    }
+  });
+
+  parser.on('extra', function (comment) {
 
     output.push(pad('  ' + format.yellow(comment.raw)) + '\n');
   });
 
   // All done
-  parser.on('output', function (results) {
+  parser.on('complete', function (results) {
 
     output.push('\n\n');
 
     // Most likely a failure upstream
-    if (results.plans.length < 1) {
-      process.exit(1);
+    if (results.plan.end < 1) {
+      return markFailed();
     }
 
-    if (results.fail.length > 0) {
+    if (results.fail > 0) {
       output.push(formatErrors(results));
       output.push('\n');
+      markFailed();
     }
 
     output.push(formatTotals(results));
@@ -82,24 +94,29 @@ module.exports = function (spec) {
     // Exit if no tests run. This is a result of 1 of 2 things:
     //  1. No tests were written
     //  2. There was some error before the TAP got to the parser
-    if (results.tests.length === 0) {
-      process.exit(1);
+    if (results.count === 0) {
+      markFailed();
     }
   });
 
   // Utils
 
-  function prettifyRawError (rawError) {
+  function markFailed() {
 
-    return rawError.split('\n').map(function (line) {
+    stream.failed = true;
+  }
 
-      return pad(line);
-    }).join('\n') + '\n\n';
+  function prettifyError (diag) {
+
+    return pad('operator: ' + diag.operator, 3) + '\n'
+      + pad('expected: ' + diag.expected, 3) + '\n'
+      + pad('actual: ' + diag.actual, 3) + '\n'
+      + pad('at: ' + diag.at, 3) + '\n\n';
   }
 
   function formatErrors (results) {
 
-    var failCount = results.fail.length;
+    var failCount = results.fail;
     var past = (failCount === 1) ? 'was' : 'were';
     var plural = (failCount === 1) ? 'failure' : 'failures';
 
@@ -111,14 +128,14 @@ module.exports = function (spec) {
 
   function formatTotals (results) {
 
-    if (results.tests.length === 0) {
+    if (results.count === 0) {
       return pad(format.red(symbols.cross + ' No tests found'));
     }
 
     return _.filter([
-      pad('total:     ' + results.asserts.length),
-      pad(format.green('passing:   ' + results.pass.length)),
-      results.fail.length > 0 ? pad(format.red('failing:   ' + results.fail.length)) : undefined,
+      pad('total:     ' + results.count),
+      pad(format.green('passing:   ' + results.pass)),
+      results.fail > 0 ? pad(format.red('failing:   ' + results.fail)) : undefined,
       pad('duration:  ' + prettyMs(new Date().getTime() - startTime))
     ], _.identity).join('\n');
   }
@@ -127,31 +144,25 @@ module.exports = function (spec) {
 
     var out = '';
 
-    var groupedAssertions = _.groupBy(results.fail, function (assertion) {
-      return assertion.test;
-    });
+    for(var test in errorSummary) {
+      var errors = errorSummary[test];
+      if(!errors.length) { continue; }
 
-    _.each(groupedAssertions, function (assertions, testNumber) {
+      out += '\n' + pad('  ' + test + '\n\n');
 
-      // Wrie failed assertion's test name
-      var test = _.find(results.tests, {number: parseInt(testNumber)});
-      out += '\n' + pad('  ' + test.name + '\n\n');
+      _.each(errors, function (name) {
 
-      // Write failed assertion
-      _.each(assertions, function (assertion) {
-
-        out += pad('    ' + format.red(symbols.cross) + ' ' + format.red(assertion.name)) + '\n';
+        out += pad('    ' + format.red(symbols.cross) + ' ' + format.red(name)) + '\n';
       });
-
-      out += '\n';
-    });
+    }
 
     return out;
   }
 
-  function pad (str) {
+  function pad (str, times) {
+    if(!times) { times = 1; }
 
-    return OUTPUT_PADDING + str;
+    return _.fill(new Array(times), OUTPUT_PADDING).join('') + str;
   }
 
   return stream;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lodash": "^3.6.0",
     "pretty-ms": "^2.1.0",
     "repeat-string": "^1.5.2",
-    "tap-out": "^1.4.1",
+    "tap-parser": "^3.0.3",
     "through2": "^2.0.0"
   },
   "bin": {


### PR DESCRIPTION
Hi

I had a usecase where I needed to use the TAP reporter from a script instead of the CLI, as I needed to share the test setup across multiple projects and thus wanted the same reporter for each project without having to set it up every time. Like so:

```javascript
tape.createStream()
      .pipe(tapDot())
      .pipe(process.stdout);
```

But the `tap-out` parser that is used is expecting a `close` event to be fired on the stream before it determines that the test is done, which works fine when used with the CLI, but from a script this event is never fired, hence making the reporter unable to finish its report.
After a bit of search I found the `tap-parser` parser which works in both CLI and script environments since it is determining when the tests are done from the stream of texts , instead of waiting for the stream to fire the `close` event.

So to make it work in my use case I have updated the code to use `tap-parser` instead.