### PR TITLE
remove dependency on lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var through = require('through2');
 var duplexer = require('duplexer');
 var format = require('chalk');
 var prettyMs = require('pretty-ms');
-var _ = require('lodash');
 var repeat = require('repeat-string');
 var symbols = require('figures');
 
@@ -44,8 +43,7 @@ module.exports = function (spec) {
     var glyph = symbols.cross;
     var title =  glyph + ' ' + assertion.name;
     var raw = format.cyan(prettifyRawError(assertion.error.raw));
-    var divider = _.fill(
-      new Array((title).length + 1),
+    var divider = new Array(title.length + 1).fill(
       '-'
     ).join('');
 
@@ -114,31 +112,32 @@ module.exports = function (spec) {
     if (results.tests.length === 0) {
       return pad(format.red(symbols.cross + ' No tests found'));
     }
-
-    return _.filter([
+ 
+    const temp = [
       pad('total:     ' + results.asserts.length),
       pad(format.green('passing:   ' + results.pass.length)),
       results.fail.length > 0 ? pad(format.red('failing:   ' + results.fail.length)) : undefined,
       pad('duration:  ' + prettyMs(new Date().getTime() - startTime))
-    ], _.identity).join('\n');
+    ];
+    return temp.join('\n');
   }
 
   function formatFailedAssertions (results) {
 
     var out = '';
 
-    var groupedAssertions = _.groupBy(results.fail, function (assertion) {
+    var groupedAssertions = results.fail.filter(function (assertion) {
       return assertion.test;
     });
 
-    _.each(groupedAssertions, function (assertions, testNumber) {
+    groupedAssertions.forEach(function (assertions, testNumber) {
 
       // Wrie failed assertion's test name
-      var test = _.find(results.tests, {number: parseInt(testNumber)});
+      var test = results.tests.find(results.tests, {number: parseInt(testNumber)});
       out += '\n' + pad('  ' + test.name + '\n\n');
 
       // Write failed assertion
-      _.each(assertions, function (assertion) {
+      assertions.forEach(function (assertion) {
 
         out += pad('    ' + format.red(symbols.cross) + ' ' + format.red(assertion.name)) + '\n';
       });

--- a/lib/utils/l-trim-list.js
+++ b/lib/utils/l-trim-list.js
@@ -1,11 +1,9 @@
-var _ = require('lodash');
-
 module.exports = function (lines) {
   
   var leftPadding;
   
   // Get minimum padding count
-  _.each(lines, function (line) {
+  lines.forEach(function (line) {
     
     var spaceLen = line.match(/^\s+/)[0].length;
     
@@ -15,7 +13,7 @@ module.exports = function (lines) {
   });
   
   // Strip padding at beginning of line
-  return _.map(lines, function (line) {
+  return lines.map(function (line) {
     
     return line.slice(leftPadding);
   });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "chalk": "^1.0.0",
     "duplexer": "^0.1.1",
     "figures": "^1.4.0",
-    "lodash": "^3.6.0",
     "pretty-ms": "^2.1.0",
     "repeat-string": "^1.5.2",
     "tap-out": "^1.4.1",


### PR DESCRIPTION
Removing the dependency on lodash makes this module ship with a sexy lean 80K instead of 2.2M (over twice the size of the testing framework Tape itself!)

I only used at latest ES6 features to replace the code that was lodash based as ES6 is the height of my knowledge of JS at the moment and is over 99% nodejs compatible since last year if memory serves me correctly. This is my first PR to an open-source project, so please do check with great skepticism that everything works well. 