### PR TITLE
Remove lodash (extends the work from #55)

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,14 +121,14 @@ module.exports = function (spec) {
     if (results.tests.length === 0) {
       return pad(format.red(symbols.cross + ' No tests found'));
     }
- 
+
     const temp = [
       pad('total:     ' + results.asserts.length),
       pad(format.green('passing:   ' + results.pass.length)),
       results.fail.length > 0 ? pad(format.red('failing:   ' + results.fail.length)) : undefined,
       pad('duration:  ' + prettyMs(new Date().getTime() - startTime))
     ];
-    return temp.join('\n');
+    return temp.filter( value => typeof value !== 'undefined' ).join('\n');
   }
 
   function formatFailedAssertions (results) {

--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ module.exports = function (spec) {
     groupedAssertions.forEach(function (assertions, testNumber) {
 
       // Wrie failed assertion's test name
-      var test = results.tests.find(results.tests, {number: parseInt(testNumber)});
+      var test = results.tests.find(function(v){ return v.number == parseInt(testNumber); });
       out += '\n' + pad('  ' + test.name + '\n\n');
 
       // Write failed assertion

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var through = require('through2');
 var duplexer = require('duplexer');
 var format = require('chalk');
 var prettyMs = require('pretty-ms');
-var _ = require('lodash');
 var repeat = require('repeat-string');
 var symbols = require('figures');
 
@@ -53,8 +52,7 @@ module.exports = function (spec) {
     var glyph = symbols.cross;
     var title =  glyph + ' ' + assertion.name;
     var raw = format.cyan(prettifyRawError(assertion.error.raw));
-    var divider = _.fill(
-      new Array((title).length + 1),
+    var divider = new Array(title.length + 1).fill(
       '-'
     ).join('');
 
@@ -123,31 +121,32 @@ module.exports = function (spec) {
     if (results.tests.length === 0) {
       return pad(format.red(symbols.cross + ' No tests found'));
     }
-
-    return _.filter([
+ 
+    const temp = [
       pad('total:     ' + results.asserts.length),
       pad(format.green('passing:   ' + results.pass.length)),
       results.fail.length > 0 ? pad(format.red('failing:   ' + results.fail.length)) : undefined,
       pad('duration:  ' + prettyMs(new Date().getTime() - startTime))
-    ], _.identity).join('\n');
+    ];
+    return temp.join('\n');
   }
 
   function formatFailedAssertions (results) {
 
     var out = '';
 
-    var groupedAssertions = _.groupBy(results.fail, function (assertion) {
+    var groupedAssertions = results.fail.filter(function (assertion) {
       return assertion.test;
     });
 
-    _.each(groupedAssertions, function (assertions, testNumber) {
+    groupedAssertions.forEach(function (assertions, testNumber) {
 
       // Wrie failed assertion's test name
-      var test = _.find(results.tests, {number: parseInt(testNumber)});
+      var test = results.tests.find(results.tests, {number: parseInt(testNumber)});
       out += '\n' + pad('  ' + test.name + '\n\n');
 
       // Write failed assertion
-      _.each(assertions, function (assertion) {
+      assertions.forEach(function (assertion) {
 
         out += pad('    ' + format.red(symbols.cross) + ' ' + format.red(assertion.name)) + '\n';
       });

--- a/lib/utils/l-trim-list.js
+++ b/lib/utils/l-trim-list.js
@@ -1,11 +1,9 @@
-var _ = require('lodash');
-
 module.exports = function (lines) {
   
   var leftPadding;
   
   // Get minimum padding count
-  _.each(lines, function (line) {
+  lines.forEach(function (line) {
     
     var spaceLen = line.match(/^\s+/)[0].length;
     
@@ -15,7 +13,7 @@ module.exports = function (lines) {
   });
   
   // Strip padding at beginning of line
-  return _.map(lines, function (line) {
+  return lines.map(function (line) {
     
     return line.slice(leftPadding);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,298 @@
+{
+  "name": "tap-spec",
+  "version": "4.1.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+    },
+    "chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "requires": {
+        "color-name": "^1.1.1"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "glob": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "dev": true,
+      "requires": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "irregular-plurals": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "parse-ms": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
+      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "plur": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+      "requires": {
+        "irregular-plurals": "^1.0.0"
+      }
+    },
+    "pretty-ms": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
+      "integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
+      "requires": {
+        "parse-ms": "^1.0.0",
+        "plur": "^2.1.2"
+      }
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "re-emitter": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/re-emitter/-/re-emitter-1.1.3.tgz",
+      "integrity": "sha1-+p4xn/3u6zWycpbvDz03TawvUqc="
+    },
+    "readable-stream": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+      "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+      "requires": {
+        "buffer-shims": "~1.0.0",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~1.0.0",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "split": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
+      "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64=",
+      "requires": {
+        "through": "2"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "tap-out": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tap-out/-/tap-out-2.0.0.tgz",
+      "integrity": "sha1-4pCSskjFzYme3jSCIZAHl6aLmNI=",
+      "requires": {
+        "re-emitter": "1.1.3",
+        "readable-stream": "2.2.9",
+        "split": "1.0.0",
+        "trim": "0.0.1"
+      }
+    },
+    "tapes": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/tapes/-/tapes-4.1.0.tgz",
+      "integrity": "sha1-RJ+L9XtjXnPna3rdWKIuw5/uPKg=",
+      "dev": true,
+      "requires": {
+        "async": "^1.5.0",
+        "glob": "^6.0.3"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "requires": {
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
+      }
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "chalk": "^1.0.0",
     "duplexer": "^0.1.1",
     "figures": "^1.4.0",
-    "lodash": "^3.6.0",
     "pretty-ms": "^2.1.0",
     "repeat-string": "^1.5.2",
     "tap-out": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -23,19 +23,19 @@
     "url": "https://github.com/scottcorgan/tap-spec/issues"
   },
   "dependencies": {
-    "chalk": "^1.0.0",
+    "chalk": "^2.4.1",
     "duplexer": "^0.1.1",
-    "figures": "^1.4.0",
-    "pretty-ms": "^2.1.0",
-    "repeat-string": "^1.5.2",
-    "tap-out": "^1.4.1",
-    "through2": "^2.0.0"
+    "figures": "^2.0.0",
+    "pretty-ms": "^3.1.0",
+    "repeat-string": "^1.6.1",
+    "tap-out": "^2.0.0",
+    "through2": "^2.0.3"
   },
   "bin": {
     "tspec": "bin/cmd.js",
     "tap-spec": "bin/cmd.js"
   },
   "devDependencies": {
-    "tapes": "^2.0.0"
+    "tapes": "^4.1.0"
   }
 }

--- a/test/e2e/index.js
+++ b/test/e2e/index.js
@@ -2,7 +2,6 @@
 
 var test = require('tapes');
 var fs = require('fs');
-var _ = require('lodash');
 var path = require('path');
 var okTestPath = path.resolve(__dirname, '..', 'fixtures', 'ok.txt');
 var notOkTestPath = path.resolve(__dirname, '..', 'fixtures', 'not-ok.txt');
@@ -82,7 +81,7 @@ test('e2e test', function(t) {
 // remove empty lines and 'duration ...' line
 // durationLinePos is the position of 'duration ...' line counting from the last line.
 function normalize(data, durationLinePos) {
-    var noEmptyLine = _.filter(data.split('\n'), function(line) { return line.trim().length !== 0; });
+    var noEmptyLine = data.split('\n').filter(function(line) { return line.trim().length !== 0; });
     noEmptyLine.splice(noEmptyLine.length - durationLinePos - 1, 1);
     return noEmptyLine.join('\n');
 }


### PR DESCRIPTION
This should remove lodash completely.

The current version of lodash tap-spec depends on is failing the new npm audit as well, so this would be a nice thing to resolve and make a new release.