### PR TITLE
refactor: replace chalk with colorette

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var tapOut = require('tap-out');
 var through = require('through2');
 var duplexer = require('duplexer');
-var format = require('chalk');
+var fmt = require('colorette');
 var prettyMs = require('pretty-ms');
 var _ = require('lodash');
 var repeat = require('repeat-string');
@@ -26,7 +26,7 @@ module.exports = function (spec) {
 
   parser.on('test', function (test) {
 
-    output.push('\n' + pad(format.underline(test.name)) + '\n\n');
+    output.push('\n' + pad(fmt.underline(test.name)) + '\n\n');
   });
 
   // Passing assertions
@@ -34,13 +34,13 @@ module.exports = function (spec) {
 
     if (/# SKIP/.test(assertion.name)) {
       var name = assertion.name.replace(' # SKIP', '')
-      name = format.cyan('- ' + name);
+      name = fmt.cyan('- ' + name);
 
       output.push(pad('  ' + name + '\n'));
     }
     else {
-      var glyph = format.green(symbols.tick);
-      var name = format.dim(assertion.name);
+      var glyph = fmt.green(symbols.tick);
+      var name = fmt.dim(assertion.name);
 
       output.push(pad('  ' + glyph + ' ' + name + '\n'));
     }
@@ -52,14 +52,14 @@ module.exports = function (spec) {
 
     var glyph = symbols.cross;
     var title =  glyph + ' ' + assertion.name;
-    var raw = format.cyan(prettifyRawError(assertion.error.raw));
+    var raw = fmt.cyan(prettifyRawError(assertion.error.raw));
     var divider = _.fill(
       new Array((title).length + 1),
       '-'
     ).join('');
 
-    output.push('\n' + pad('  ' + format.red(title) + '\n'));
-    output.push(pad('  ' + format.red(divider) + '\n'));
+    output.push('\n' + pad('  ' + fmt.red(title) + '\n'));
+    output.push(pad('  ' + fmt.red(divider) + '\n'));
     output.push(raw);
 
     stream.failed = true;
@@ -67,7 +67,7 @@ module.exports = function (spec) {
 
   parser.on('comment', function (comment) {
 
-    output.push(pad('  ' + format.yellow(comment.raw)) + '\n');
+    output.push(pad('  ' + fmt.yellow(comment.raw)) + '\n');
   });
 
   // All done
@@ -113,7 +113,7 @@ module.exports = function (spec) {
     var past = (failCount === 1) ? 'was' : 'were';
     var plural = (failCount === 1) ? 'failure' : 'failures';
 
-    var out = '\n' + pad(format.red.bold('Failed Tests:') + ' There ' + past + ' ' + format.red.bold(failCount) + ' ' + plural + '\n');
+    var out = '\n' + pad(fmt.red(fmt.bold('Failed Tests:')) + ' There ' + past + ' ' + fmt.red(fmt.bold(failCount)) + ' ' + plural + '\n');
     out += formatFailedAssertions(results);
 
     return out;
@@ -123,13 +123,13 @@ module.exports = function (spec) {
 
     if (results.tests.length === 0 &&
         results.asserts.length === 0) {
-      return pad(format.red(symbols.cross + ' No tests found'));
+      return pad(fmt.red(symbols.cross + ' No tests found'));
     }
 
     return _.filter([
       pad('total:     ' + results.asserts.length),
-      pad(format.green('passing:   ' + results.pass.length)),
-      results.fail.length > 0 ? pad(format.red('failing:   ' + results.fail.length)) : undefined,
+      pad(fmt.green('passing:   ' + results.pass.length)),
+      results.fail.length > 0 ? pad(fmt.red('failing:   ' + results.fail.length)) : undefined,
       pad('duration:  ' + prettyMs(new Date().getTime() - startTime))
     ], _.identity).join('\n');
   }
@@ -151,7 +151,7 @@ module.exports = function (spec) {
       // Write failed assertion
       _.each(assertions, function (assertion) {
 
-        out += pad('    ' + format.red(symbols.cross) + ' ' + format.red(assertion.name)) + '\n';
+        out += pad('    ' + fmt.red(symbols.cross) + ' ' + fmt.red(assertion.name)) + '\n';
       });
 
       out += '\n';

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,16 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-    },
     "async": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
@@ -41,17 +31,10 @@
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
     },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      }
+    "colorette": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.0.5.tgz",
+      "integrity": "sha512-7mcpZLRdXqHLaOhGfKaDD/K7UjLSp6MkrDT6DziQ/HKBxqV3G1yLZAc14UCP8bCQAJTbcvd4k6MGRVYUa4NmHw=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -176,14 +159,6 @@
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
-      }
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "^2.0.0"
       }
     },
     "inflight": {
@@ -402,19 +377,6 @@
       "requires": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
-    "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "tap-out": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/scottcorgan/tap-spec/issues"
   },
   "dependencies": {
-    "chalk": "^1.0.0",
+    "colorette": "^1.0.5",
     "duplexer": "^0.1.1",
     "figures": "^1.4.0",
     "lodash": "^4.17.10",

--- a/test/e2e/index.js
+++ b/test/e2e/index.js
@@ -6,7 +6,7 @@ var _ = require('lodash');
 var path = require('path');
 var okTestPath = path.resolve(__dirname, '..', 'fixtures', 'ok.txt');
 var notOkTestPath = path.resolve(__dirname, '..', 'fixtures', 'not-ok.txt');
-var format = require('chalk');
+var fmt = require('colorette');
 var symbols = {
     ok: '\u2713',
     err: '\u2717'
@@ -26,14 +26,14 @@ test('e2e test', function(t) {
         t.plan(1);
         var testOutStream = fs.createReadStream(okTestPath);
         var expected = ' '.repeat(2) + 'beep\n' +
-                ' '.repeat(4) + format.green(symbols.ok) + ' ' + format.gray('should be equal') + '\n' +
-                ' '.repeat(4) + format.green(symbols.ok) + ' ' + format.gray('should be equivalent') + '\n' +
+                ' '.repeat(4) + fmt.green(symbols.ok) + ' ' + fmt.gray('should be equal') + '\n' +
+                ' '.repeat(4) + fmt.green(symbols.ok) + ' ' + fmt.gray('should be equivalent') + '\n' +
                 ' '.repeat(2) + 'boop\n' +
-                ' '.repeat(4) + format.green(symbols.ok) + ' ' + format.gray('should be equal') + '\n' +
-                ' '.repeat(4) + format.green(symbols.ok) + ' ' + format.gray('(unnamed assert)') + '\n' +
+                ' '.repeat(4) + fmt.green(symbols.ok) + ' ' + fmt.gray('should be equal') + '\n' +
+                ' '.repeat(4) + fmt.green(symbols.ok) + ' ' + fmt.gray('(unnamed assert)') + '\n' +
                 ' '.repeat(2) + 'total:' + ' '.repeat(5) + '4\n' +
-                format.green(' '.repeat(2) + 'passing:' + ' '.repeat(3) + 4) + '\n' +
-                ' '.repeat(2) + format.green.bold('All tests pass!');
+                fmt.green(' '.repeat(2) + 'passing:' + ' '.repeat(3) + 4) + '\n' +
+                ' '.repeat(2) + fmt.green(fmt.bold('All tests pass!'));
 
         testOutStream.pipe(tapSpec);
         tapSpec.on('data', function(data) {
@@ -50,21 +50,21 @@ test('e2e test', function(t) {
         var testOutStream = fs.createReadStream(notOkTestPath);
         var expected = ' '.repeat(2) + 'THIS IS A SUITE\n' +
             ' '.repeat(2) + 'test 1\n' +
-            ' '.repeat(4) + format.green(symbols.ok) + ' ' + format.gray('this test should pass') + '\n' +
+            ' '.repeat(4) + fmt.green(symbols.ok) + ' ' + fmt.gray('this test should pass') + '\n' +
             ' '.repeat(2) + 'test 2\n' +
-            ' '.repeat(4) + format.red(symbols.err) + ' ' + format.gray('this test should fail') + '\n' +
-            ' '.repeat(3) + format.yellow('  ---') + '\n' +
-            ' '.repeat(3) + format.yellow('    operator: ok') + '\n' +
-            ' '.repeat(3) + format.yellow('    expected: true') + '\n' +
-            ' '.repeat(3) + format.yellow('    actual:   false') + '\n' +
-            ' '.repeat(3) + format.yellow('    at: Test.<anonymous> (/Users/khanh.nguyen/tap-spec/test.js:13:15)') + '\n' +
-            ' '.repeat(3) + format.yellow('  ...') + '\n' +
-            ' '.repeat(2) + format.red.bold('Failed Tests: ') + 'There was ' + format.red.bold(1) + ' failure\n' +
+            ' '.repeat(4) + fmt.red(symbols.err) + ' ' + fmt.gray('this test should fail') + '\n' +
+            ' '.repeat(3) + fmt.yellow('  ---') + '\n' +
+            ' '.repeat(3) + fmt.yellow('    operator: ok') + '\n' +
+            ' '.repeat(3) + fmt.yellow('    expected: true') + '\n' +
+            ' '.repeat(3) + fmt.yellow('    actual:   false') + '\n' +
+            ' '.repeat(3) + fmt.yellow('    at: Test.<anonymous> (/Users/khanh.nguyen/tap-spec/test.js:13:15)') + '\n' +
+            ' '.repeat(3) + fmt.yellow('  ...') + '\n' +
+            ' '.repeat(2) + fmt.red(fmt.bold('Failed Tests: ')) + 'There was ' + fmt.red(fmt.bold(1)) + ' failure\n' +
             ' '.repeat(4) + '3) test 2\n' +
-            ' '.repeat(6) + format.red(symbols.err) + ' ' + format.red('this test should fail') + '\n' +
+            ' '.repeat(6) + fmt.red(symbols.err) + ' ' + fmt.red('this test should fail') + '\n' +
             ' '.repeat(2) + 'total:' + ' '.repeat(5) + '2\n' +
-            format.green(' '.repeat(2) + 'passing:' + ' '.repeat(3) + 1) + '\n' +
-            format.red(' '.repeat(2) + 'failing:' + ' '.repeat(3) + 1);
+            fmt.green(' '.repeat(2) + 'passing:' + ' '.repeat(3) + 1) + '\n' +
+            fmt.red(' '.repeat(2) + 'failing:' + ' '.repeat(3) + 1);
 
         testOutStream.pipe(tapSpec);
         tapSpec.on('data', function(data) {
@@ -90,4 +90,3 @@ function normalize(data, durationLinePos) {
 String.prototype.repeat = function(n) {
     return new Array(n + 1).join(this);
 }
-

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,6 +1,6 @@
 var ts = require('../..');
 var test = require('tapes');
-var format = require('chalk');
+var fmt = require('colorette');
 var symbols = {
     ok: '\u2713',
     err: '\u2717'
@@ -38,7 +38,7 @@ test('unit test', function(t) {
     t.test('Assert ok', function(t) {
         t.plan(1);
         var assert = 'ok 1 this is an ok assertion\n';
-        var expected = '    ' + format.green(symbols.ok) + ' ' + format.gray('this is an ok assertion') + '\n';
+        var expected = '    ' + fmt.green(symbols.ok) + ' ' + fmt.gray('this is an ok assertion') + '\n';
 
         rs.on('end', function() {
             t.equal(actual, expected, 'Should format ok assertion correctly.');
@@ -52,7 +52,7 @@ test('unit test', function(t) {
     t.test('Assert not ok', function(t) {
         t.plan(1);
         var assert = 'not ok 1 this is a not-ok assertion\n';
-        var expected = '    ' + format.red(symbols.err) + ' ' + format.gray('this is a not-ok assertion') + '\n';
+        var expected = '    ' + fmt.red(symbols.err) + ' ' + fmt.gray('this is a not-ok assertion') + '\n';
 
         rs.on('end', function() {
             t.equal(actual, expected, 'Should format not-ok assertion correctly.');
@@ -66,7 +66,7 @@ test('unit test', function(t) {
     t.test('Extra', function(t) {
         t.plan(1);
         var extra = 'something extra that does not match any other regex\n';
-        var expected = '   ' + format.yellow('something extra that does not match any other regex') + '\n';
+        var expected = '   ' + fmt.yellow('something extra that does not match any other regex') + '\n';
 
         rs.on('end', function() {
             t.equal(actual, expected, 'Should format extra correctly.');


### PR DESCRIPTION
This PR replaces chalk with colorette which is [faster](https://github.com/jorgebucaran/colorette#benchmark-results) for a fraction of the [size](https://packagephobia.now.sh/result?p=colorette).

Related #62

cc @scottcorgan