### PR TITLE
Update lodash to address audited vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tap-spec",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -242,9 +242,9 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tap-spec",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Formatted TAP output like Mocha's spec reporter",
   "main": "index.js",
   "scripts": {
@@ -26,7 +26,7 @@
     "chalk": "^1.0.0",
     "duplexer": "^0.1.1",
     "figures": "^1.4.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.14",
     "pretty-ms": "^2.1.0",
     "repeat-string": "^1.5.2",
     "tap-out": "^2.1.0",


### PR DESCRIPTION
Address the high severity vulnerability reported by GitHub and npm audit when installing tap-spec.

Issue reference: https://github.com/scottcorgan/tap-spec/issues/67

The [current version of lodash](https://github.com/scottcorgan/tap-spec/blob/5.0.0/package-lock.json#L244) (4.17.10) that tap-spec depends on has a [high severity vulnerability](https://snyk.io/vuln/SNYK-JS-LODASH-73638). Lodash applied a [fix](https://github.com/lodash/lodash/pull/4336) for 4.17.13.

The vunerablity only affects the following lodash functions, `merge`, `mergeWith` and `defaultsDeep`, which aren't actually used in this library. But it would be nice to upgrade it anyway as it would mean that consumers of tap-spec can trust the library implicitly. At the moment GitHub (and npm audit) alerts users of this vulnerability when installing tap-spec and you have to manually check that the library doesn't use the above lodash functions.

Thanks 😄